### PR TITLE
Add share metadata and mobile QR code modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,17 +8,23 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <link rel="icon" type="image/svg+xml" href="./brand/logo-mark.svg" />
-    <title>Hack‑A‑Bot 2026</title>
-    <meta name="description" content="[Add a concise description for the Hack‑A‑Bot 2026 landing page]" />
+    <link rel="icon" type="image/png" href="/brand/Logo.png" />
+    <link rel="apple-touch-icon" href="/brand/Logo.png" />
+    <title>Hack‑A‑Bot 2026 • Manchester’s Premier Student Hackathon</title>
+    <meta name="description" content="Manchester’s premier student hackathon returns 28–29 March 2026 at the Nancy Rothwell Building in Manchester. Join us for 24 hours of creativity, collaboration, and cutting-edge robotics." />
     <meta property="og:title" content="Hack‑A‑Bot 2026" />
-    <meta property="og:description" content="[Placeholder: add share description]" />
-    <meta property="og:image" content="/og-placeholder.png" />
+    <meta property="og:description" content="Manchester’s Premier Student Hackathon. Join us 28–29 March 2026 at the Nancy Rothwell Building in Manchester." />
+    <meta property="og:image" content="/brand/Title_Date_Logo_BG.png" />
+    <meta property="og:image:alt" content="Hack‑A‑Bot 2026 logo with event date" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://aj-floater.github.io/hackabot-2026/" />
+    <meta property="og:site_name" content="Hack‑A‑Bot 2026" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Hack‑A‑Bot 2026" />
-    <meta name="twitter:description" content="[Placeholder: add share description]" />
-    <meta name="twitter:image" content="/og-placeholder.png" />
+    <meta name="twitter:description" content="Manchester’s Premier Student Hackathon. Join us 28–29 March 2026 in Manchester." />
+    <meta name="twitter:image" content="/brand/Title_Date_Logo_BG.png" />
+    <meta name="twitter:image:alt" content="Hack‑A‑Bot 2026 logo with event date" />
   </head>
   <body>
     <a href="#hero" class="skip-link">Skip to content</a>

--- a/src/app/components/Nav/NavBar.tsx
+++ b/src/app/components/Nav/NavBar.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react'
-import { Group, Container, Anchor, Button, Burger, Stack, ScrollArea, Collapse } from '@mantine/core'
+import { Group, Container, Anchor, Button, Burger, Stack, ScrollArea, Collapse, Modal, Text, Paper } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { smoothScrollTo } from '../../lib/anchors'
 import { assetPath } from '../../lib/assets'
+import event from '../../data/event.json'
+import QRCode from 'react-qr-code'
+import { QR_CARD_TITLE, QR_TARGET_URL } from '../QR/constants'
 import './Nav.css'
 
 const links = [
@@ -17,6 +20,14 @@ const links = [
 export function NavBar() {
   const [active, setActive] = useState('#hero')
   const [opened, { toggle, close }] = useDisclosure(false)
+  const [qrModalOpen, setQrModalOpen] = useState(false)
+
+  const openQrModal = () => {
+    close()
+    requestAnimationFrame(() => setQrModalOpen(true))
+  }
+
+  const closeQrModal = () => setQrModalOpen(false)
 
   useEffect(() => {
     const observers: IntersectionObserver[] = []
@@ -40,56 +51,91 @@ export function NavBar() {
   }, [])
 
   return (
-    <div className="nav-glass">
-      <Container size="lg" h={72} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16 }}>
-        <Group gap={0} align="center">
-          <Anchor href="#hero" underline="never" onClick={(e) => { e.preventDefault(); smoothScrollTo('hero') }} style={{ display: 'flex', alignItems: 'center' }}>
-            <img src={assetPath('brand/Header_Logo.png')} alt="Hack‑A‑Bot" height={44} style={{ display: 'block', height: '44px', width: 'auto' }} />
-          </Anchor>
-        </Group>
-        <Group gap={24} visibleFrom="md" align="center">
-          {links.map((l) => (
-            <Anchor
-              key={l.href}
-              href={l.href}
-              underline="never"
-              className={`nav-link${active === l.href ? ' active' : ''}`}
-              aria-current={active === l.href ? 'page' : undefined}
-              onClick={(e) => { e.preventDefault(); smoothScrollTo(l.href.slice(1)) }}
-            >
-              {l.label}
+    <>
+      <Modal
+        opened={qrModalOpen}
+        onClose={closeQrModal}
+        title={`Scan to open ${event.name}`}
+        centered
+        radius="lg"
+        padding="lg"
+        overlayProps={{ opacity: 0.65, blur: 6 }}
+        data-testid="qr-modal"
+      >
+        <Stack align="center" gap="sm">
+          <Paper withBorder radius="lg" p="lg" shadow="md">
+            <QRCode value={QR_TARGET_URL} size={196} bgColor="transparent" fgColor="var(--text)" />
+          </Paper>
+          <Text ta="center" fz="sm" c="var(--text)">
+            {event.tagline}
+          </Text>
+          <Text ta="center" fz="xs" c="var(--text-dim)">
+            {QR_CARD_TITLE}
+          </Text>
+        </Stack>
+      </Modal>
+
+      <div className="nav-glass">
+        <Container size="lg" h={72} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16 }}>
+          <Group gap={0} align="center">
+            <Anchor href="#hero" underline="never" onClick={(e) => { e.preventDefault(); smoothScrollTo('hero') }} style={{ display: 'flex', alignItems: 'center' }}>
+              <img src={assetPath('brand/Header_Logo.png')} alt="Hack‑A‑Bot" height={44} style={{ display: 'block', height: '44px', width: 'auto' }} />
             </Anchor>
-          ))}
-        </Group>
+          </Group>
+          <Group gap={24} visibleFrom="md" align="center">
+            {links.map((l) => (
+              <Anchor
+                key={l.href}
+                href={l.href}
+                underline="never"
+                className={`nav-link${active === l.href ? ' active' : ''}`}
+                aria-current={active === l.href ? 'page' : undefined}
+                onClick={(e) => { e.preventDefault(); smoothScrollTo(l.href.slice(1)) }}
+              >
+                {l.label}
+              </Anchor>
+            ))}
+          </Group>
 
-        {/* Mobile: burger only; Register moves into menu */}
-        <Group gap={12} hiddenFrom="md">
-          <Burger opened={opened} onClick={toggle} aria-label="Toggle navigation" color="var(--text)" />
-        </Group>
-      </Container>
+          {/* Mobile: burger only; Register moves into menu */}
+          <Group gap={12} hiddenFrom="md">
+            <Burger opened={opened} onClick={toggle} aria-label="Toggle navigation" color="var(--text)" />
+          </Group>
+        </Container>
 
-      <Collapse in={opened} transitionDuration={180}>
-        <div className="nav-mobile-panel">
-          <ScrollArea style={{ maxHeight: 'calc(100dvh - 72px)' }} offsetScrollbars>
-            <Stack gap="xs" p="md">
-              {links.map((l) => (
-              <Button
-                  key={l.href}
-                  variant="subtle"
+        <Collapse in={opened} transitionDuration={180}>
+          <div className="nav-mobile-panel">
+            <ScrollArea style={{ maxHeight: 'calc(100dvh - 72px)' }} offsetScrollbars>
+              <Stack gap="xs" p="md">
+                {links.map((l) => (
+                  <Button
+                    key={l.href}
+                    variant="subtle"
+                    size="lg"
+                    fullWidth
+                    aria-current={active === l.href ? 'page' : undefined}
+                    styles={{ root: { justifyContent: 'flex-start' } }}
+                    onClick={(e) => { e.preventDefault(); close(); requestAnimationFrame(() => smoothScrollTo(l.href.slice(1))) }}
+                  >
+                    {l.label}
+                  </Button>
+                ))}
+                <Button
+                  variant="gradient"
+                  gradient={{ from: 'red', to: 'pink', deg: 135 }}
                   size="lg"
                   fullWidth
-                  aria-current={active === l.href ? 'page' : undefined}
                   styles={{ root: { justifyContent: 'flex-start' } }}
-                  onClick={(e) => { e.preventDefault(); close(); requestAnimationFrame(() => smoothScrollTo(l.href.slice(1))) }}
+                  onClick={openQrModal}
                 >
-                  {l.label}
+                  Show event QR code
                 </Button>
-              ))}
-            </Stack>
-          </ScrollArea>
-        </div>
-      </Collapse>
-    </div>
+              </Stack>
+            </ScrollArea>
+          </div>
+        </Collapse>
+      </div>
+    </>
   )
 }
 

--- a/src/app/components/QR/TopRightQRCode.tsx
+++ b/src/app/components/QR/TopRightQRCode.tsx
@@ -1,15 +1,14 @@
 import { Paper, Stack, Text } from '@mantine/core'
 import QRCode from 'react-qr-code'
+import { QR_CARD_TITLE, QR_TARGET_URL } from './constants'
 import './TopRightQRCode.css'
 
-const TARGET_URL = 'https://aj-floater.github.io/hackabot-2026/'
-
-export function TopRightQRCode(){
+export function TopRightQRCode() {
   return (
-    <div className="qr-affix" aria-label="Hack-A-Bot 2026 quick access QR" role="complementary">
+    <div className="qr-affix" aria-label={QR_CARD_TITLE} role="complementary">
       <Paper withBorder radius="lg" p="md" className="qr-card">
         <Stack align="center" gap={8}>
-          <QRCode value={TARGET_URL} size={108} bgColor="transparent" fgColor="var(--text)" />
+          <QRCode value={QR_TARGET_URL} size={108} bgColor="transparent" fgColor="var(--text)" />
           <Text fz="xs" c="var(--text-dim)" tt="uppercase" fw={600}>
             Scan for site
           </Text>

--- a/src/app/components/QR/constants.ts
+++ b/src/app/components/QR/constants.ts
@@ -1,0 +1,3 @@
+export const QR_TARGET_URL = 'https://aj-floater.github.io/hackabot-2026/' as const
+
+export const QR_CARD_TITLE = 'Hack‑A‑Bot 2026 quick access QR' as const


### PR DESCRIPTION
## Summary
- add polished document title, icon, and social sharing metadata that highlight the Hack‑A‑Bot 2026 tagline
- centralize the QR code configuration for reuse and keep the desktop quick-access card accessible
- add a mobile-only QR code modal that opens from the navigation burger menu and closes the menu automatically

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f6525b248327baafbe451ff1c5e6